### PR TITLE
Reproduce in localhost

### DIFF
--- a/postgres/docker-compose.yaml
+++ b/postgres/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  db:
+    image: 'postgres:latest'
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+#volumes:
+#  db:
+#    driver: local

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,12 +1,12 @@
 -- Create a mock table
-CREATE TABLE companies (
-  id SERIAL PRIMARY KEY,
-  company_id NUMERIC(19),
-  name VARCHAR(255)
+CREATE TABLE companies(
+    company_id SERIAL PRIMARY KEY,
+    company_name VARCHAR(255)
 );
 
-INSERT INTO companies (company_id, name) VALUES (10, 'John Doe');
-INSERT INTO companies (company_id, name) VALUES (11, 'Jane Smith');
+-- Some sample data generation.
+INSERT INTO companies(company_name)
+    SELECT md5(random()::text) FROM generate_series(1, 100000);
 
 CREATE TABLE insert_table (
   id SERIAL PRIMARY KEY,

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,0 +1,14 @@
+-- Create a mock table
+CREATE TABLE companies (
+  id SERIAL PRIMARY KEY,
+  company_id NUMERIC(19),
+  name VARCHAR(255)
+);
+
+INSERT INTO companies (company_id, name) VALUES (10, 'John Doe');
+INSERT INTO companies (company_id, name) VALUES (11, 'Jane Smith');
+
+CREATE TABLE insert_table (
+  id SERIAL PRIMARY KEY,
+  uuid VARCHAR(255)
+);

--- a/server-mvc-jdbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-mvc-jdbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -10,7 +10,7 @@ import javax.sql.DataSource;
 @Configuration
 public class DataSourceConfiguration {
 
-    public static final int CONNECTION_POOL_SIZE = 200;
+    public static final int CONNECTION_POOL_SIZE = 100;
 
     @Bean
     public DataSource dataSource() {

--- a/server-mvc-jdbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-mvc-jdbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -15,7 +15,7 @@ public class DataSourceConfiguration {
     @Bean
     public DataSource dataSource() {
         HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://192.168.1.120:5432/postgres");
+        config.setJdbcUrl("jdbc:postgresql://localhost:5432/postgres");
         config.setUsername("postgres");
         config.setPassword("postgres");
         config.setDriverClassName("org.postgresql.Driver");

--- a/server-mvc-jdbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-mvc-jdbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -15,6 +15,7 @@ public class DataSourceConfiguration {
     @Bean
     public DataSource dataSource() {
         HikariConfig config = new HikariConfig();
+//        config.setJdbcUrl("jdbc:postgresql://192.168.1.120:5432/postgres");
         config.setJdbcUrl("jdbc:postgresql://localhost:5432/postgres");
         config.setUsername("postgres");
         config.setPassword("postgres");

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/BenchmarkService.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/BenchmarkService.java
@@ -46,7 +46,7 @@ public class BenchmarkService {
         long timeStartNs = System.nanoTime();
         Mono<Long> zip = Mono.zip(dbCallMonos, objects -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - timeStartNs));
         zip.subscribe(durationMs -> {
-            Long seconds = TimeUnit.MILLISECONDS.toSeconds(durationMs);
+            long seconds = TimeUnit.MILLISECONDS.toSeconds(durationMs);
             durationMs = durationMs - TimeUnit.SECONDS.toMillis(seconds);
 
             System.out.println("select " + SELECTS_COUNT + " in " + seconds + "." + durationMs + "s.");

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/BenchmarkService.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/BenchmarkService.java
@@ -44,7 +44,15 @@ public class BenchmarkService {
         //   2. Otherwise, if it's slow, it'd be another indicator something is wrong in WebFlux+R2DBC setup.
         // Take it into account, if you decide to add more logic when playing with it.
         long timeStartNs = System.nanoTime();
-        return Mono.zip(dbCallMonos, objects -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - timeStartNs));
+        Mono<Long> zip = Mono.zip(dbCallMonos, objects -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - timeStartNs));
+        zip.subscribe(durationMs -> {
+            Long seconds = TimeUnit.MILLISECONDS.toSeconds(durationMs);
+            durationMs = durationMs - TimeUnit.SECONDS.toMillis(seconds);
+
+            System.out.println("select " + SELECTS_COUNT + " in " + seconds + "." + durationMs + "s.");
+        });
+
+        return zip;
     }
 
     private Mono<Long> selectCompanyById(Long id) {

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/Controller.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/Controller.java
@@ -14,6 +14,7 @@ public class Controller {
     /**
      *
      * @return benchmark run duration Mono in milliseconds
+     * curl --location 'http://localhost:8080/benchmark'
      */
     @GetMapping("/benchmark")
     public Mono<Long> runBenchmark() {

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -22,6 +22,7 @@ public class DataSourceConfiguration {
         return ConnectionFactories.get(ConnectionFactoryOptions.builder()
                 .option(DRIVER, "postgresql")
                 .option(PROTOCOL, "postgresql")
+//                .option(HOST, "192.168.1.120")
                 .option(HOST, "localhost")
                 .option(PORT, 5432)
                 .option(USER, "postgres")

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -22,7 +22,7 @@ public class DataSourceConfiguration {
         return ConnectionFactories.get(ConnectionFactoryOptions.builder()
                 .option(DRIVER, "postgresql")
                 .option(PROTOCOL, "postgresql")
-                .option(HOST, "192.168.1.120")
+                .option(HOST, "localhost")
                 .option(PORT, 5432)
                 .option(USER, "postgres")
                 .option(PASSWORD, "postgres")

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -15,7 +15,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.*;
 @Configuration
 public class DataSourceConfiguration {
 
-    private static final int CONNECTION_POOL_SIZE = 200;
+    private static final int CONNECTION_POOL_SIZE = 100;
 
     @Bean
     public ConnectionFactory connectionFactory() {
@@ -46,7 +46,7 @@ public class DataSourceConfiguration {
         ConnectionPool connectionPool = new ConnectionPool(configuration);
 
         System.out.println("Warming up connection pool...");
-        connectionPool.warmup().block();
+        connectionPool.warmup().subscribe();
         System.out.println("Warmed up connection pool.");
 
         return connectionPool;

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -28,7 +28,8 @@ public class DataSourceConfiguration {
                 .option(USER, "postgres")
                 .option(PASSWORD, "postgres")
                 .option(DATABASE, "postgres")
-                .option(PostgresqlConnectionFactoryProvider.LOOP_RESOURCES, new NioClientEventLoopResources(Runtime.getRuntime().availableProcessors()))
+                .option(PostgresqlConnectionFactoryProvider.LOOP_RESOURCES, new SimpleEventLoopResource())
+//                .option(PostgresqlConnectionFactoryProvider.LOOP_RESOURCES, new NioClientEventLoopResources(Runtime.getRuntime().availableProcessors()))
                 .build());
     }
 

--- a/server-webflux-r2dbc-benchmark/src/main/java/org/example/SimpleEventLoopResource.java
+++ b/server-webflux-r2dbc-benchmark/src/main/java/org/example/SimpleEventLoopResource.java
@@ -1,0 +1,39 @@
+package org.example;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import reactor.netty.resources.LoopResources;
+
+import java.util.concurrent.ThreadFactory;
+
+import static java.lang.Math.max;
+
+public class SimpleEventLoopResource implements LoopResources {
+
+    private static Integer DEFAULT_ACCEPTOR_THREADS = 1;
+    private final String prefix = "r2dbc";
+
+    public SimpleEventLoopResource() {
+
+    }
+    public SimpleEventLoopResource(Integer thread) {
+        if (thread != null) {
+            DEFAULT_ACCEPTOR_THREADS = thread;
+        }
+    }
+
+    @Override
+    public EventLoopGroup onServerSelect(boolean useNative) {
+        ThreadFactory threadFactory = new DefaultThreadFactory(prefix + "-acceptor", useNative);
+        return new NioEventLoopGroup(DEFAULT_ACCEPTOR_THREADS, threadFactory);
+    }
+
+    @Override
+    public EventLoopGroup onServer(boolean useNative) {
+        ThreadFactory threadFactory = new DefaultThreadFactory(prefix + "-worker", useNative);
+        int processor = Runtime.getRuntime().availableProcessors();
+        return new NioEventLoopGroup(max(processor, DEFAULT_ACCEPTOR_THREADS), threadFactory);
+    }
+
+}

--- a/server-webflux-vertx-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-webflux-vertx-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -14,6 +14,7 @@ public class DataSourceConfiguration {
     public SqlClient sqlClient() {
         PgConnectOptions connectOptions = new PgConnectOptions()
                 .setPort(5432)
+//                .setHost("192.168.1.120")
                 .setHost("localhost")
                 .setDatabase("postgres")
                 .setUser("postgres")

--- a/server-webflux-vertx-benchmark/src/main/java/org/example/DataSourceConfiguration.java
+++ b/server-webflux-vertx-benchmark/src/main/java/org/example/DataSourceConfiguration.java
@@ -14,7 +14,7 @@ public class DataSourceConfiguration {
     public SqlClient sqlClient() {
         PgConnectOptions connectOptions = new PgConnectOptions()
                 .setPort(5432)
-                .setHost("192.168.1.120")
+                .setHost("localhost")
                 .setDatabase("postgres")
                 .setUser("postgres")
                 .setPassword("postgres")

--- a/standalone-jdbc-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-jdbc-benchmark/src/main/java/org/example/DataSource.java
@@ -14,7 +14,7 @@ public class DataSource {
 
     static {
         HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://192.168.1.120:5432/postgres");
+        config.setJdbcUrl("jdbc:postgresql://localhost:5432/postgres");
         config.setUsername("postgres");
         config.setPassword("postgres");
         config.setDriverClassName("org.postgresql.Driver");

--- a/standalone-jdbc-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-jdbc-benchmark/src/main/java/org/example/DataSource.java
@@ -8,7 +8,7 @@ import java.sql.SQLException;
 
 public class DataSource {
 
-    public static final int CONNECTION_POOL_SIZE = 200;
+    public static final int CONNECTION_POOL_SIZE = 100;
 
     private static final HikariDataSource DATA_SOURCE;
 

--- a/standalone-jdbc-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-jdbc-benchmark/src/main/java/org/example/DataSource.java
@@ -14,6 +14,7 @@ public class DataSource {
 
     static {
         HikariConfig config = new HikariConfig();
+//        config.setJdbcUrl("jdbc:postgresql://192.168.1.120:5432/postgres");
         config.setJdbcUrl("jdbc:postgresql://localhost:5432/postgres");
         config.setUsername("postgres");
         config.setPassword("postgres");

--- a/standalone-r2dbc-benchmark/src/main/java/org/example/BenchmarkService.java
+++ b/standalone-r2dbc-benchmark/src/main/java/org/example/BenchmarkService.java
@@ -25,9 +25,12 @@ public class BenchmarkService {
         long timeStartNs = System.nanoTime();
 
         Mono<Long> zip = Mono.zip(dbCallMonos, results -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - timeStartNs));
-        Long durationMs = zip.block();
+        zip.subscribe(durationMs -> {
+            long seconds = TimeUnit.MILLISECONDS.toSeconds(durationMs);
+            durationMs = durationMs - TimeUnit.SECONDS.toMillis(seconds);
 
-        System.out.println(durationMs);
+            System.out.println("select " + SELECTS_COUNT + " in " + seconds + "." + durationMs + "s.");
+        });
     }
 
     private static Mono<Long> selectCompanyById(Long id) {

--- a/standalone-r2dbc-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-r2dbc-benchmark/src/main/java/org/example/DataSource.java
@@ -24,6 +24,7 @@ public class DataSource {
         ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
                 .option(DRIVER, "postgresql")
                 .option(PROTOCOL, "postgresql")
+//                .option(HOST, "192.168.1.120")
                 .option(HOST, "localhost")
                 .option(PORT, 5432)
                 .option(USER, "postgres")

--- a/standalone-r2dbc-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-r2dbc-benchmark/src/main/java/org/example/DataSource.java
@@ -14,7 +14,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.*;
 
 public class DataSource {
 
-    private static final int CONNECTION_POOL_SIZE = 200;
+    private static final int CONNECTION_POOL_SIZE = 100;
 
     private static final ConnectionPool CONNECTION_POOL;
 

--- a/standalone-r2dbc-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-r2dbc-benchmark/src/main/java/org/example/DataSource.java
@@ -24,7 +24,7 @@ public class DataSource {
         ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
                 .option(DRIVER, "postgresql")
                 .option(PROTOCOL, "postgresql")
-                .option(HOST, "192.168.1.120")
+                .option(HOST, "localhost")
                 .option(PORT, 5432)
                 .option(USER, "postgres")
                 .option(PASSWORD, "postgres")

--- a/standalone-r2dbc-benchmark/src/main/java/org/example/SimpleEventLoopResource.java
+++ b/standalone-r2dbc-benchmark/src/main/java/org/example/SimpleEventLoopResource.java
@@ -1,0 +1,39 @@
+package org.example;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import reactor.netty.resources.LoopResources;
+
+import java.util.concurrent.ThreadFactory;
+
+import static java.lang.Math.max;
+
+public class SimpleEventLoopResource implements LoopResources {
+
+    private static Integer DEFAULT_ACCEPTOR_THREADS = 1;
+    private final String prefix = "r2dbc";
+
+    public SimpleEventLoopResource() {
+
+    }
+    public SimpleEventLoopResource(Integer thread) {
+        if (thread != null) {
+            DEFAULT_ACCEPTOR_THREADS = thread;
+        }
+    }
+
+    @Override
+    public EventLoopGroup onServerSelect(boolean useNative) {
+        ThreadFactory threadFactory = new DefaultThreadFactory(prefix + "-acceptor", useNative);
+        return new NioEventLoopGroup(DEFAULT_ACCEPTOR_THREADS, threadFactory);
+    }
+
+    @Override
+    public EventLoopGroup onServer(boolean useNative) {
+        ThreadFactory threadFactory = new DefaultThreadFactory(prefix + "-worker", useNative);
+        int processor = Runtime.getRuntime().availableProcessors();
+        return new NioEventLoopGroup(max(processor, DEFAULT_ACCEPTOR_THREADS), threadFactory);
+    }
+
+}

--- a/standalone-vertx-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-vertx-benchmark/src/main/java/org/example/DataSource.java
@@ -12,7 +12,7 @@ public class DataSource {
     static {
         PgConnectOptions connectOptions = new PgConnectOptions()
                 .setPort(5432)
-                .setHost("192.168.1.120")
+                .setHost("localhost")
                 .setDatabase("postgres")
                 .setUser("postgres")
                 .setPassword("postgres")

--- a/standalone-vertx-benchmark/src/main/java/org/example/DataSource.java
+++ b/standalone-vertx-benchmark/src/main/java/org/example/DataSource.java
@@ -12,6 +12,7 @@ public class DataSource {
     static {
         PgConnectOptions connectOptions = new PgConnectOptions()
                 .setPort(5432)
+//                .setHost("192.168.1.120")
                 .setHost("localhost")
                 .setDatabase("postgres")
                 .setUser("postgres")


### PR DESCRIPTION
change of this PR:

- DataSourceConfiguration
<details><summary>Details</summary>
<p>
change ip `192.168.1.120` to `localhost`
change CONNECTION_POOL_SIZE from `200` to `100` (my com limits)
run local db and mock data by docker compose
</p>
</details> 

2. SimpleEventLoopResource
<details><summary>Details</summary>
<p>

just my try to make LoopResources not my suggestion

</p>
</details> 

- remove block() function
```java
        Long durationMs = zip.block();

        System.out.println(durationMs);
``` 
change to 
```java
        zip.subscribe(durationMs -> {
            long seconds = TimeUnit.MILLISECONDS.toSeconds(durationMs);
            durationMs = durationMs - TimeUnit.SECONDS.toMillis(seconds);

            System.out.println("select " + SELECTS_COUNT + " in " + seconds + "." + durationMs + "s.");
        });
``` 
i'm think after change block() it's a little bit better
but my test

spring-webflux + r2dbc + r2dbc-pool and not custom LoopResources is too bad performance

without r2dbc-pool (config) it's better then config more and more pool

thank for your work

